### PR TITLE
audio: sc8830: Set i2s port parameter as AP_TYPE

### DIFF
--- a/audio/sc8830/audio_hw.c
+++ b/audio/sc8830/audio_hw.c
@@ -1926,8 +1926,8 @@ static int start_output_stream(struct tiny_stream_out *out)
         /* FIXME: only works if only one output can be active at a time*/
         adev->out_devices &= (~AUDIO_DEVICE_OUT_ALL_EX);
         adev->out_devices |= out->devices;
-        if(adev->out_devices & AUDIO_DEVICE_OUT_ALL_SCO)
-            i2s_pin_mux_sel(adev, 2);
+        //if(adev->out_devices & AUDIO_DEVICE_OUT_ALL_SCO)
+            i2s_pin_mux_sel(adev, AP_TYPE);
 
 	adev->prev_out_devices = ~adev->out_devices;
         select_devices_signal(adev);
@@ -2277,7 +2277,7 @@ static int out_set_parameters(struct audio_stream *stream, const char *kvpairs)
             }
             else {
                 if(adev->out_devices & AUDIO_DEVICE_OUT_ALL_SCO) {
-                    i2s_pin_mux_sel(adev, 2);
+                    i2s_pin_mux_sel(adev, AP_TYPE);
                 }
             }
             cur_mode = adev->mode;
@@ -2946,7 +2946,7 @@ static int start_input_stream(struct tiny_stream_in *in)
         adev->in_devices |= in->device;
         if((in->device & ~ AUDIO_DEVICE_BIT_IN) & AUDIO_DEVICE_IN_BLUETOOTH_SCO_HEADSET) {
             if(!adev->voip_start) {
-                i2s_pin_mux_sel(adev, 2);
+                i2s_pin_mux_sel(adev, AP_TYPE);
             }else {
                 if(adev->cp_type == CP_TG)
                     i2s_pin_mux_sel(adev,1);


### PR DESCRIPTION
For this one: https://github.com/remilia15/android_device_samsung_scx35-common/blob/cm-14.1/configs/audio/audio_hw.xml#L25

Defined in vb_control_parameters.h:
typedef enum {
    CP_W,
    CP_TG,
    CP_CSFB,
    AP_TYPE = 3 ,
    CP_MAX,
    FM_IIS
}cp_type_t;

Change-Id: I99a046b775627864475cd1491be8246871a1e28d
Signed-off-by: Remilia Scarlet <remilia.1505@gmail.com>